### PR TITLE
loader: override fewer packages

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -232,7 +232,6 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"":                            true,
 		"crypto/":                     true,
 		"crypto/rand/":                false,
-		"crypto/tls/":                 false,
 		"crypto/x509/":                true,
 		"crypto/x509/internal/":       true,
 		"crypto/x509/internal/macos/": false,

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -249,7 +249,6 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"internal/wasi/":              false,
 		"machine/":                    false,
 		"net/":                        true,
-		"net/http/":                   false,
 		"os/":                         true,
 		"reflect/":                    false,
 		"runtime/":                    false,


### PR DESCRIPTION
Testing out removal of TinyGo-specific package overrides of the Go standard library.

- [ ] `crypto/tls`
- [ ] `crypto/x509`
- [ ] `net/http` — requires `crypto/tls`
- [ ] `net` — unlikely, with TinyGo `netdev` interface